### PR TITLE
Hotfix to Bugzilla

### DIFF
--- a/src/recon3d.c
+++ b/src/recon3d.c
@@ -287,8 +287,8 @@ void MBIRReconstruct(
 
     // Limit threads for smaller problem size regardless of positivity constraint
     int max_threads = omp_get_max_threads();
-    i = ((Nx < Ny) ? Nx : Ny) / (2*SVLength+1) * (Nz/SVDEPTH);
-    i = ((i<1) ? 1 : i);
+    int max_of_num_slices_svdepth = ((Nz < SVDEPTH) ? Nz : SVDEPTH);
+    i = (((Nx < Ny) ? Nx : Ny) / (2*SVLength+1)) * (max_of_num_slices_svdepth/SVDEPTH);
     max_threads = ( i < max_threads) ? i : max_threads ;
     fprintf(stdout, "auto max_threads = %d\n", max_threads);
     #pragma omp parallel num_threads(max_threads)

--- a/src/recon3d.c
+++ b/src/recon3d.c
@@ -285,13 +285,12 @@ void MBIRReconstruct(
         #endif
     }
 
-    // Limit threads for smaller problem size if no positivity constraint
+    // Limit threads for smaller problem size regardless of positivity constraint
     int max_threads = omp_get_max_threads();
-    if(reconparams.Positivity==0) {
-        i = ((Nx < Ny) ? Nx : Ny) / (2*SVLength+1) * SV_per_Z;
-        max_threads = ( i < max_threads) ? i : max_threads ;
-    }
-
+    i = ((Nx < Ny) ? Nx : Ny) / (2*SVLength+1) * (Nz/SVDEPTH);
+    i = ((i<1) ? 1 : i);
+    max_threads = ( i < max_threads) ? i : max_threads ;
+    fprintf(stdout, "auto max_threads = %d\n", max_threads);
     #pragma omp parallel num_threads(max_threads)
     {
         while(stop_FLAG==0 && equits<MaxIterations && iter<100*MaxIterations)


### PR DESCRIPTION
This is a hot fix to the bugzilla problem in svmbir, as described here: https://github.com/cabouman/svmbir/issues/268

What we observed is that Bugzilla occurs for `num_slices=5`, for which `max_threads=26`. However, the problem did not occur for `num_slices=4`, for which `max_threads=13`. 

We think this is because we took the ceiling instead of floor function when calculating `SV_per_Z=num_slices/SVDEPTH`.

A solution is proposed in the link above. I copied it here:

Replace lines 290-293 of recon3d.c with the following:

    max_of_num_slices_svdepth = ((num_slices < SVDEPTH) ? num_slices : SVDEPTH)
    i = (((Nx < Ny) ? Nx : Ny) / (2*SVLength+1)) * (max_of_num_slices_svdepth/SVDEPTH);
    max_threads = ( i < max_threads) ? i : max_threads ;
Previously, the problem is that

SV_per_Z = ceil( num_slices/SVDEPTH )
So that we could allow overlap between SVs when the number of slices was not an integer multiple of the SV depth.


After the fix, the convergence behavior is back to normal for `num_slices=3,4,5,6,7,8`.